### PR TITLE
post status using a github proxy if it is defined

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ def generate_config():
         config['github_user'] = conf.get('GitHub', 'user')
         config['github_pw'] = conf.get('GitHub', 'password')
         config['github_token'] = conf.get('GitHub', 'token')
-        config['github_proxy'] = conf.get('GitHub', 'proxy')
+        config['github_proxy'] = conf.get('GitHub', 'proxy', fallback=None)
         config['github_status_text'] = conf.get('GitHub', 'status_check_text')
         config['github_status_url'] = conf.get('GitHub', 'status_check_url')
     else:
@@ -69,8 +69,6 @@ def get_credentials():
 
 
 def get_proxy():
-    if CONFIG['github_proxy'] == '':
-        return None
     return CONFIG['github_proxy']
 
 

--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ def generate_config():
         config['github_user'] = conf.get('GitHub', 'user')
         config['github_pw'] = conf.get('GitHub', 'password')
         config['github_token'] = conf.get('GitHub', 'token')
+        config['github_proxy'] = conf.get('GitHub', 'proxy')
         config['github_status_text'] = conf.get('GitHub', 'status_check_text')
         config['github_status_url'] = conf.get('GitHub', 'status_check_url')
     else:
@@ -37,6 +38,7 @@ def generate_config():
         config['github_user'] = os.environ.get('GITHUB_USER', None)
         config['github_pw'] = os.environ.get('GITHUB_PW', None)
         config['github_token'] = os.environ.get('GITHUB_TOKEN', None)
+        config['github_proxy'] = os.environ.get('GITHUB_PROXY', None)
         config['github_status_text'] = os.environ.get('GITHUB_STATUS_TEXT', 'Label requirements not satisfied.')
         config['github_status_url'] = os.environ.get('GITHUB_STATUS_URL', '')
 
@@ -64,6 +66,12 @@ def get_credentials():
     if CONFIG['github_user'] == '' or CONFIG['github_pw'] == '':
         return None
     return CONFIG['github_user'], CONFIG['github_pw']
+
+
+def get_proxy():
+    if CONFIG['github_proxy'] == '':
+        return None
+    return CONFIG['github_proxy']
 
 
 UNIT_TESTING = any([arg for arg in sys.argv if 'test' in arg])

--- a/tests/fixtures/custom.conf.test
+++ b/tests/fixtures/custom.conf.test
@@ -9,5 +9,6 @@ banned-labels:
 user: someuser
 password:
 token:
+proxy: https://ghproxy.github.com
 status_check_text: Label requirements not satisfied
 status_check_url: https://somewhere_with_more_information.com

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,10 +35,12 @@ class TestGenerateConfig(unittest.TestCase):
         with patch.dict(os.environ, {'CONFIG_FILE': fixture_config}):
             config = generate_config()
             assert config['github_user'] == 'someuser'
+            assert config['github_proxy'] == 'https://ghproxy.github.com'
             assert config['github_status_text'] == "Label requirements not satisfied"
             assert config['github_status_url'] == "https://somewhere_with_more_information.com"
     
     def test_it_source_config_from_environment(self):
-        with patch.dict(os.environ, {'GITHUB_USER': 'ghuser'}):
+        with patch.dict(os.environ, {'GITHUB_USER': 'ghuser', 'GITHUB_PROXY': 'https://ghproxy.github.com'}):
             config = generate_config()
             assert config['github_user'] == 'ghuser'
+            assert config['github_proxy'] == 'https://ghproxy.github.com'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,3 +27,11 @@ class TestPullRequest(unittest.TestCase):
         PullRequest({'pull_request': {'issue_url': 'https/github/orga/url/issueurl'}})
         get_token.assert_called_once()
         get_credentials.assert_called_once()
+
+    @patch('utils.Session', MagicMock())
+    @patch('utils.get_proxy')
+    def test_it_calls_proxy_config_during_init(self,
+                                               get_proxy):
+        get_proxy.return_value = 'https://ghproxy.github.com/api/v3/'
+        pr = PullRequest({'pull_request': {'issue_url': 'https://api.github.com/orga/url/issueurl'}})
+        assert pr.github_proxy == 'https://ghproxy.github.com/api/v3/'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,11 @@
+import unittest
 from unittest.mock import patch, MagicMock
 
 from exceptions import NoGitHubTokenException
 from utils import PullRequest
 
 
-class TestPullRequest():
+class TestPullRequest(unittest.TestCase):
     @patch('utils.Session', MagicMock())
     @patch('utils.get_credentials')
     @patch('utils.get_token')

--- a/utils.py
+++ b/utils.py
@@ -2,13 +2,14 @@ import json
 from requests import Session
 
 from exceptions import NoGitHubTokenException
-from config import get_token, get_credentials, APP_NAME
+from config import get_token, get_credentials, get_proxy, APP_NAME
 
 
 class PullRequest:
     def __init__(self, event=None):
         self.event = event
         self._session = Session()
+        self.github_proxy = get_proxy()
         try:
             self._session.headers.update({"Authorization": f"token {get_token()}"})
         except NoGitHubTokenException:
@@ -41,6 +42,8 @@ class PullRequest:
 
     @property
     def statuses_url(self):
+        if self.github_proxy is not None:
+           return self.event['pull_request']['statuses_url'].replace("https://api.github.com/", self.github_proxy)
         return self.event['pull_request']['statuses_url']
 
     def create_status_json(self, required_any, required_all, banned, status_text, status_target_url):


### PR DESCRIPTION
## Summary of Changes
* when posting changes to the github api, replace the `api.github.com` string with the contents of the github_proxy variable. 
* create configuration variable to set a github proxy, environment variable is `GITHUB_PROXY` and configuration file variable is `proxy` under the `[Github]` section
* allow unittests for utils
* unable to test `statuses_url` because it is not callable as a property. Not sure how to test this part.

## Unit Test
```
aaron0317mac:required-labels asprou$ pwd; python3 -m unittest -v
/Users/asprou/code/required-labels
test_it_reads_default_config_file (tests.test_config.TestGenerateConfig) ... ok
test_it_reads_given_config_file_from_environment_var (tests.test_config.TestGenerateConfig) ... ok
test_it_source_config_from_environment (tests.test_config.TestGenerateConfig) ... ok
test_it_source_config_from_environment_with_missing_conf (tests.test_config.TestGenerateConfig) ... ok
test_it_source_config_from_given_config_file (tests.test_config.TestGenerateConfig) ... ok
test_all_fails (tests.test_label_assertion.LabelAssertionTests) ... ok
test_all_passes (tests.test_label_assertion.LabelAssertionTests) ... ok
test_banned_fails (tests.test_label_assertion.LabelAssertionTests) ... ok
test_banned_passes (tests.test_label_assertion.LabelAssertionTests) ... ok
test_pr_with_no_labels_no_requirements (tests.test_label_assertion.LabelAssertionTests) ... ok
test_required_any_fails (tests.test_label_assertion.LabelAssertionTests) ... ok
test_required_any_passes (tests.test_label_assertion.LabelAssertionTests) ... ok
test_it_calls_proxy_config_during_init (tests.test_utils.TestPullRequest) ... ok
test_it_fallback_to_login_password_authentication_with_no_token (tests.test_utils.TestPullRequest) ... ok
test_it_use_login_token_authentication (tests.test_utils.TestPullRequest) ... ok

----------------------------------------------------------------------
Ran 15 tests in 0.017s

OK
```