### PR TITLE
FIX: use github proxy for GETs as well as POSTs

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,4 +34,20 @@ class TestPullRequest(unittest.TestCase):
                                                get_proxy):
         get_proxy.return_value = 'https://ghproxy.github.com/api/v3/'
         pr = PullRequest({'pull_request': {'issue_url': 'https://api.github.com/orga/url/issueurl'}})
-        assert pr.github_proxy == 'https://ghproxy.github.com/api/v3/'
+        self.assertEqual(pr.github_proxy, 'https://ghproxy.github.com/api/v3/')
+
+    @patch('utils.Session', MagicMock())
+    @patch('utils.get_proxy')
+    def test_it_uses_proxy_status_url(self,
+                                      get_proxy):
+        get_proxy.return_value = 'https://ghproxy.github.com/api/v3/'
+        pr = PullRequest({'pull_request': {'statuses_url': 'https://api.github.com/orga/url/statuses_url', 'issue_url': 'https://api.github.com/orga/url/issueurl'}})
+        self.assertEqual(pr.statuses_url, 'https://ghproxy.github.com/api/v3/orga/url/statuses_url')
+
+    @patch('utils.Session', MagicMock())
+    @patch('utils.get_proxy')
+    def test_it_gets_patched_label_urls(self,
+                                        get_proxy):
+        get_proxy.return_value = 'https://ghproxy.github.com/api/v3/'
+        pr = PullRequest({'pull_request': {'issue_url': 'https://api.github.com/orga/url/issueurl'}})
+        self.assertEqual(pr.label_url, 'https://ghproxy.github.com/api/v3/orga/url/issueurl/labels')

--- a/utils.py
+++ b/utils.py
@@ -31,6 +31,8 @@ class PullRequest:
 
     @property
     def label_url(self):
+        if self.github_proxy is not None:
+           return "{}/labels".format(self.issue_url).replace("https://api.github.com/", self.github_proxy)
         return "{}/labels".format(self.issue_url)
 
     def compute_and_post_status(self, required_any, required_all, banned, status_text, status_target_url):


### PR DESCRIPTION
Following https://github.com/LiveRamp/required-labels/pull/2, this change switches the label url to point to the github proxy if its specified.

I also use `self.assertEqual` as it prints helpful diffs if the tests fail. e.g.:
```
======================================================================
FAIL: test_it_uses_proxy_status_url (tests.test_utils.TestPullRequest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/mock.py", line 1255, in patched
    return func(*args, **keywargs)
  File "/Users/pmally/code/LiveRamp/required-labels/tests/test_utils.py", line 45, in test_it_uses_proxy_status_url
    self.assertEqual(pr.statuses_url, 'https://ghproxy.github.com/api/v3/')
AssertionError: 'https://ghproxy.github.com/api/v3/orga/url/statuses_url' != 'https://ghproxy.github.com/api/v3/'
- https://ghproxy.github.com/api/v3/orga/url/statuses_url
?                                   ---------------------
+ https://ghproxy.github.com/api/v3/


----------------------------------------------------------------------
```

```
$ python3 -m unittest -v && git rev-parse HEAD
test_it_reads_default_config_file (tests.test_config.TestGenerateConfig) ... ok
test_it_reads_given_config_file_from_environment_var (tests.test_config.TestGenerateConfig) ... ok
test_it_source_config_from_environment (tests.test_config.TestGenerateConfig) ... ok
test_it_source_config_from_environment_with_missing_conf (tests.test_config.TestGenerateConfig) ... ok
test_it_source_config_from_given_config_file (tests.test_config.TestGenerateConfig) ... ok
test_all_fails (tests.test_label_assertion.LabelAssertionTests) ... ok
test_all_passes (tests.test_label_assertion.LabelAssertionTests) ... ok
test_banned_fails (tests.test_label_assertion.LabelAssertionTests) ... ok
test_banned_passes (tests.test_label_assertion.LabelAssertionTests) ... ok
test_pr_with_no_labels_no_requirements (tests.test_label_assertion.LabelAssertionTests) ... ok
test_required_any_fails (tests.test_label_assertion.LabelAssertionTests) ... ok
test_required_any_passes (tests.test_label_assertion.LabelAssertionTests) ... ok
test_it_calls_proxy_config_during_init (tests.test_utils.TestPullRequest) ... ok
test_it_fallback_to_login_password_authentication_with_no_token (tests.test_utils.TestPullRequest) ... ok
test_it_gets_patched_label_urls (tests.test_utils.TestPullRequest) ... ok
test_it_use_login_token_authentication (tests.test_utils.TestPullRequest) ... ok
test_it_uses_proxy_status_url (tests.test_utils.TestPullRequest) ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.014s

OK
66f64a8e8ea7a854760625a12cd32f4e150c528f
```