### PR TITLE
Add REQUIRED_ENV_LABELS second required-any group

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -33,6 +33,7 @@ export GITHUB_TOKEN="your_github_token"
 export REQUIRED_LABELS_ANY="bug,feature,enhancement"
 export REQUIRED_LABELS_ALL="reviewed"
 export BANNED_LABELS="wip,draft"
+export REQUIRED_ENV_LABELS="Prod,Non-prod"
 ```
 
 ### 3. Run the Application
@@ -165,6 +166,7 @@ curl -H "Authorization: token YOUR_TOKEN" https://api.github.com/rate_limit
 REQUIRED_LABELS_ANY="bug,feature,enhancement"  # At least one required
 REQUIRED_LABELS_ALL="reviewed,tested"          # All required
 BANNED_LABELS="wip,draft,do-not-merge"         # None allowed
+REQUIRED_ENV_LABELS="Prod,Non-prod"            # At least one required (independent group)
 ```
 
 ### GitHub Status Configuration

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Set up the required labels (comma separated):
 - `REQUIRED_LABELS_ANY`: At least one of these labels should be present on all PRs
 - `REQUIRED_LABELS_ALL`: All of these labels must be present on all PRs
 - `BANNED_LABELS`: None of these labels can be present on all PRs
+- `REQUIRED_ENV_LABELS`: A second, independent "any-of" group. At least one of these labels must be present on all PRs, in addition to satisfying `REQUIRED_LABELS_ANY` (e.g. `Prod,Non-prod`)
 
 Enter the credentials:
 

--- a/config.py
+++ b/config.py
@@ -25,6 +25,7 @@ def generate_config():
         config['required_any'] = conf.get('Labels', 'required-labels-any')
         config['required_all'] = conf.get('Labels', 'required-labels-all')
         config['banned'] = conf.get('Labels', 'banned-labels')
+        config['required_env'] = conf.get('Labels', 'required-env-labels', fallback=None)
         config['github_user'] = conf.get('GitHub', 'user')
         config['github_pw'] = conf.get('GitHub', 'password')
         config['github_token'] = conf.get('GitHub', 'token')
@@ -35,6 +36,7 @@ def generate_config():
         config['required_any'] = os.environ.get('REQUIRED_LABELS_ANY', None)
         config['required_all'] = os.environ.get('REQUIRED_LABELS_ALL', None)
         config['banned'] = os.environ.get('BANNED_LABELS', None)
+        config['required_env'] = os.environ.get('REQUIRED_ENV_LABELS', None)
         config['github_user'] = os.environ.get('GITHUB_USER', None)
         config['github_pw'] = os.environ.get('GITHUB_PW', None)
         config['github_token'] = os.environ.get('GITHUB_TOKEN', None)
@@ -42,7 +44,7 @@ def generate_config():
         config['github_status_text'] = os.environ.get('GITHUB_STATUS_TEXT', 'Label requirements not satisfied.')
         config['github_status_url'] = os.environ.get('GITHUB_STATUS_URL', '')
 
-    for label in ['required_any', 'required_all', 'banned']:
+    for label in ['required_any', 'required_all', 'banned', 'required_env']:
         config[label] = config[label].split(',') if config[label] else None
     return config
 
@@ -77,7 +79,7 @@ UNIT_TESTING = any([arg for arg in sys.argv if 'test' in arg])
 
 if not UNIT_TESTING:
     labels_configured = any([CONFIG['required_any'], CONFIG['required_all'],
-                             CONFIG['banned']])
+                             CONFIG['banned'], CONFIG['required_env']])
     credentials_configured = any([all([CONFIG['github_pw'], CONFIG['github_user']]),
                                   CONFIG['github_token']])
     if not labels_configured or not credentials_configured:

--- a/custom.conf.template
+++ b/custom.conf.template
@@ -3,6 +3,9 @@
 required-labels-any:
 required-labels-all:
 banned-labels:
+# required-env-labels: a second, independent "any-of" group. A PR must carry at least one of these
+# labels in addition to satisfying required-labels-any (e.g. Prod,Non-prod).
+required-env-labels:
 
 [GitHub]
 # The authentication method to use

--- a/main.py
+++ b/main.py
@@ -45,11 +45,12 @@ def main():
             logger.info(f"[{request_id}] Checking labels for PR {pull_request.issue_url}")
             
             status_code = pull_request.compute_and_post_status(
-                CONFIG['required_any'], 
-                CONFIG['required_all'], 
-                CONFIG['banned'], 
+                CONFIG['required_any'],
+                CONFIG['required_all'],
+                CONFIG['banned'],
                 CONFIG['github_status_text'],
                 CONFIG['github_status_url'],
+                required_env=CONFIG['required_env'],
             )
             
             duration = (datetime.now() - start_time).total_seconds()
@@ -132,6 +133,7 @@ def config():
             'required_any': CONFIG.get('required_any', []),
             'required_all': CONFIG.get('required_all', []),
             'banned': CONFIG.get('banned', []),
+            'required_env': CONFIG.get('required_env', []),
             'github_status_text': CONFIG.get('github_status_text', ''),
             'github_user_configured': bool(CONFIG.get('github_user')),
             'github_token_configured': bool(CONFIG.get('github_token')),
@@ -151,7 +153,7 @@ def test_configuration():
         issues = []
         
         # Check label configuration
-        if not any([CONFIG.get('required_any'), CONFIG.get('required_all'), CONFIG.get('banned')]):
+        if not any([CONFIG.get('required_any'), CONFIG.get('required_all'), CONFIG.get('banned'), CONFIG.get('required_env')]):
             issues.append("No label requirements configured")
             
         # Check GitHub credentials

--- a/tests/resources/change_and_prod_labels.json
+++ b/tests/resources/change_and_prod_labels.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 200000001,
+    "url": "https://api.github.com/repos/LiveRamp/example/labels/change%2Fmajor",
+    "name": "change/major",
+    "color": "d93f0b",
+    "default": false
+  },
+  {
+    "id": 200000002,
+    "url": "https://api.github.com/repos/LiveRamp/example/labels/Prod",
+    "name": "Prod",
+    "color": "0e8a16",
+    "default": false
+  }
+]

--- a/tests/resources/change_only_labels.json
+++ b/tests/resources/change_only_labels.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 200000003,
+    "url": "https://api.github.com/repos/LiveRamp/example/labels/change%2Fstandard",
+    "name": "change/standard",
+    "color": "0e8a16",
+    "default": false
+  }
+]

--- a/tests/resources/nonprod_only_labels.json
+++ b/tests/resources/nonprod_only_labels.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 200000004,
+    "url": "https://api.github.com/repos/LiveRamp/example/labels/Non-prod",
+    "name": "Non-prod",
+    "color": "1d76db",
+    "default": false
+  }
+]

--- a/tests/test_label_assertion.py
+++ b/tests/test_label_assertion.py
@@ -5,6 +5,8 @@ from tests.utils import MockPullRequest
 NO_LABELS = None
 MOBILE_PRODUCT_LABELS = ['product/all-users', 'product/custom', 'product/invisible', 'product/internal-or-flagged']
 MULTIPLE_LABELS = ['cross requested', 'product/internal-or-flagged', 'ready for review']
+CHANGE_LABELS = ['change/standard', 'change/major']
+ENV_LABELS = ['Prod', 'Non-prod']
 
 
 # To run (from parent directory): $ python -m unittest tests.LabelAssertionTests
@@ -37,6 +39,31 @@ class LabelAssertionTests(unittest.TestCase):
     def test_all_fails(self):
         pr = MockPullRequest(os.path.join(os.path.dirname(__file__), 'resources', 'pr_1830_labels.json'))
         self.assertFalse(pr.validate_labels(required_any=NO_LABELS, required_all=MULTIPLE_LABELS, banned=NO_LABELS))
+
+    def test_required_env_passes(self):
+        pr = MockPullRequest(os.path.join(os.path.dirname(__file__), 'resources', 'nonprod_only_labels.json'))
+        self.assertTrue(pr.validate_labels(required_any=NO_LABELS, required_all=NO_LABELS, banned=NO_LABELS,
+                                           required_env=ENV_LABELS))
+
+    def test_required_env_fails(self):
+        pr = MockPullRequest(os.path.join(os.path.dirname(__file__), 'resources', 'change_only_labels.json'))
+        self.assertFalse(pr.validate_labels(required_any=NO_LABELS, required_all=NO_LABELS, banned=NO_LABELS,
+                                            required_env=ENV_LABELS))
+
+    def test_both_groups_pass(self):
+        pr = MockPullRequest(os.path.join(os.path.dirname(__file__), 'resources', 'change_and_prod_labels.json'))
+        self.assertTrue(pr.validate_labels(required_any=CHANGE_LABELS, required_all=NO_LABELS, banned=NO_LABELS,
+                                           required_env=ENV_LABELS))
+
+    def test_change_present_but_env_missing_fails(self):
+        pr = MockPullRequest(os.path.join(os.path.dirname(__file__), 'resources', 'change_only_labels.json'))
+        self.assertFalse(pr.validate_labels(required_any=CHANGE_LABELS, required_all=NO_LABELS, banned=NO_LABELS,
+                                            required_env=ENV_LABELS))
+
+    def test_env_present_but_change_missing_fails(self):
+        pr = MockPullRequest(os.path.join(os.path.dirname(__file__), 'resources', 'nonprod_only_labels.json'))
+        self.assertFalse(pr.validate_labels(required_any=CHANGE_LABELS, required_all=NO_LABELS, banned=NO_LABELS,
+                                            required_env=ENV_LABELS))
 
 
 if __name__ == '__main__':

--- a/utils.py
+++ b/utils.py
@@ -138,14 +138,15 @@ class PullRequest:
             return base_url.replace("https://api.github.com/", self.github_proxy)
         return base_url
 
-    def compute_and_post_status(self, required_any, required_all, banned, status_text, status_target_url):
+    def compute_and_post_status(self, required_any, required_all, banned, status_text, status_target_url, required_env=None):
         """Compute status and post with enhanced logging"""
         logger.info(f"[{self.request_id}] Computing and posting status")
         logger.info(f"[{self.request_id}] Required any: {required_any}")
         logger.info(f"[{self.request_id}] Required all: {required_all}")
         logger.info(f"[{self.request_id}] Banned: {banned}")
-        
-        return self.post_status(self.create_status_json(required_any, required_all, banned, status_text, status_target_url))
+        logger.info(f"[{self.request_id}] Required env: {required_env}")
+
+        return self.post_status(self.create_status_json(required_any, required_all, banned, status_text, status_target_url, required_env))
 
     def post_status(self, status_json):
         """Post status with comprehensive error handling and logging"""
@@ -193,11 +194,11 @@ class PullRequest:
             return base_url.replace("https://api.github.com/", self.github_proxy)
         return base_url
 
-    def create_status_json(self, required_any, required_all, banned, status_text, status_target_url):
+    def create_status_json(self, required_any, required_all, banned, status_text, status_target_url, required_env=None):
         """Create status JSON with enhanced logging"""
         logger.info(f"[{self.request_id}] Creating status JSON")
-        
-        passes_label_requirements = self.validate_labels(required_any, required_all, banned)
+
+        passes_label_requirements = self.validate_labels(required_any, required_all, banned, required_env)
         
         if passes_label_requirements:
             description = "Label requirements satisfied."
@@ -218,7 +219,7 @@ class PullRequest:
         
         return json.dumps(response_json)
 
-    def validate_labels(self, required_any, required_all, banned):
+    def validate_labels(self, required_any, required_all, banned, required_env=None):
         """Validate labels with enhanced logging and error handling"""
         logger.info(f"[{self.request_id}] Validating labels")
         
@@ -238,7 +239,15 @@ class PullRequest:
                            f"(need one of: {required_any})")
                 if not has_required_any:
                     return False
-            
+
+            # Check required_env (second independent any-of group)
+            if required_env is not None:
+                has_required_env = any(l in required_env for l in labels_list)
+                logger.info(f"[{self.request_id}] Required env check: {has_required_env} "
+                           f"(need one of: {required_env})")
+                if not has_required_env:
+                    return False
+
             # Check required_all
             if required_all is not None:
                 missing_required = [l for l in required_all if l not in labels_list]


### PR DESCRIPTION
## Summary
Adds a second, independent "any-of" label group to the required-labels webhook app. A PR must now satisfy **both**:
- at least one of `REQUIRED_LABELS_ANY` (e.g. `change/major`, `change/standard`), and
- at least one of the new `REQUIRED_ENV_LABELS` group (e.g. `Prod`, `Non-prod`).

Simply appending `Prod,Non-prod` to `REQUIRED_LABELS_ANY` would be incorrect — it would let a PR pass with only a `change/*` label. This adds a genuine second group.

## Behavior
```
PASS: [change/major, Prod]        FAIL: [change/major]   # missing env label
PASS: [change/standard, Non-prod] FAIL: [Prod]           # missing change label
```

## Changes
- **config.py** — new `required_env` from `REQUIRED_ENV_LABELS` env var (and `required-env-labels` config-file key with `fallback=None`); added to the comma-split loop and `labels_configured` startup check.
- **utils.py** — thread `required_env` (default `None`) through `compute_and_post_status` → `create_status_json` → `validate_labels`, with an independent any-of check mirroring `required_any`.
- **main.py** — pass `CONFIG['required_env']` in the webhook handler, expose on `/config`, include in `test_configuration()`.
- **Tests** — 5 new cases + 3 fixtures in `tests/`.
- **Docs/template** — `custom.conf.template`, `README.md`, `DEPLOYMENT_GUIDE.md`.

## Testing
- All 22 unit tests pass (`python -m unittest -v`), including the 5 new cases.
- End-to-end smoke test confirmed: `[change/major, Prod]` → success; `[change/standard]` only → failure; `[Non-prod]` only → failure.

## Rollout note
Once merged to `master`, the `DevOps-kube` container image must be rebuilt (it pulls `master` at build time), then the Helm chart / Terraform PRs pin the new image tag.

JIRA tkt : https://liveramp.atlassian.net/browse/DEV-6486